### PR TITLE
Fix D3 types package version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "@types/d3": "^7.8.7",
+    "@types/d3": "^7.4.3",
     "@types/node": "^20.11.30",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",


### PR DESCRIPTION
This PR fixes the npm dependency issue with `@types/d3@^7.8.7` by updating to a valid version `^7.4.3` that exists on npm registry. The previous version was causing installation errors as it does not exist in the npm registry.