### PR TITLE
Fix entry point file path in index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR fixes the Vite pre-transform error that was occurring because the `index.html` file was still referencing the old entry point file `main.jsx`, which doesn't exist after the TypeScript migration.

The actual entry point file is now `main.tsx`, so I've updated the script tag in `index.html` to point to this file instead.

This resolves the error:
```
[vite] Pre-transform error: Failed to load url /src/main.jsx (resolved id: /src/main.jsx). Does the file exist?
```